### PR TITLE
Check frontend value for NULL before comparing it

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -474,7 +474,7 @@ static void update_variables(void)
    var.key = "vbam-next-gamepad";
    var.value = NULL;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "original") == 0)
          device_type = 0;


### PR DESCRIPTION
I was working on RetroPlayer and noticed several cores crashing when NULL was returned in various instances. In this case, it doesn't look like libretro.h prohibits this, so data from the frontend should be checked.
