### PR TITLE
Fix off-by-one error on video output.

### DIFF
--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -3902,7 +3902,7 @@ void CPULoop(int ticks)
                 case 16:
                 {
 #ifdef __LIBRETRO__
-                  u16 *dest = (u16 *)pix + 240 * (VCOUNT+1);
+                  u16 *dest = (u16 *)pix + 240 * VCOUNT;
 #else
                   u16 *dest = (u16 *)pix + 242 * (VCOUNT+1);
 #endif
@@ -3928,7 +3928,9 @@ void CPULoop(int ticks)
                     *dest++ = systemColorMap16[lineMix[x++]&0xFFFF];
                   }
                   // for filters that read past the screen
+#ifndef __LIBRETRO__
                   *dest++ = 0;
+#endif
                 }
                 break;
                 case 24:
@@ -3976,7 +3978,7 @@ void CPULoop(int ticks)
                 case 32:
                 {
 #ifdef __LIBRETRO__
-                  u32 *dest = (u32 *)pix + 240 * (VCOUNT+1);
+                  u32 *dest = (u32 *)pix + 240 * VCOUNT;
 #else
                   u32 *dest = (u32 *)pix + 241 * (VCOUNT+1);
 #endif


### PR DESCRIPTION
I'd prefer getting rid of the LIBRETRO ifdefs, but iirc it boosts performance to use packed textures, so ifdef it is.
But we should at least not trim off the top row.
