### PR TITLE
Fix Iridion II freeze at boss (#21).

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -332,6 +332,8 @@ static const ini_t gbaover[256] = {
 			{"Game Boy Wars Advance 1+2 (Japan)",					"BGWJ",	131072,	0,	0,	0,	0},
 			{"Golden Sun - The Lost Age (USA)",					"AGFE",	65536,	0,	0,	1,	0},
 			{"Golden Sun (USA)",							"AGSE",	65536,	0,	0,	1,	0},
+			{"Iridion II (Europe) (En,Fr,De)",							"AI2P",	0,	5,	0,	0,	0},
+			{"Iridion II (USA)",							"AI2E",	0,	5,	0,	0,	0},
 			{"Koro Koro Puzzle - Happy Panechu! (Japan)",				"KHPJ",	0,	4,	0,	0,	0},
 			{"Mario vs. Donkey Kong (Europe)",					"BM5P",	0,	3,	0,	0,	0},
 			{"Pocket Monsters - Emerald (Japan)",					"BPEJ",	131072,	0,	1,	0,	0},


### PR DESCRIPTION
User should remove the previous *.srm file. Upstream fixed it without this override. It's working.