### PR TITLE
regparm does not exist on aarch64, don't try to use it

### DIFF
--- a/src/gba/GBAcpu.h
+++ b/src/gba/GBAcpu.h
@@ -5,7 +5,7 @@ extern int armExecute();
 extern int thumbExecute();
 
 #ifdef __GNUC__
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__aarch64__)
 # define INSN_REGPARM __attribute__((regparm(1)))
 #else
 # define INSN_REGPARM /*nothing*/


### PR DESCRIPTION
This fixes the build on android arm64-v8a. Tested on Tegra X1.