### PR TITLE
Future proof android jni makefiles

### DIFF
--- a/src/libretro/jni/Application.mk
+++ b/src/libretro/jni/Application.mk
@@ -1,2 +1,3 @@
 APP_ABI := all
-APP_STL := stlport_static
+APP_STL := gnustl_static
+NDK_TOOLCHAIN_VERSION := 4.9


### PR DESCRIPTION
stlport has been deprecated for some time and gnustl works as is
Core fails to compile with clang, so force gcc 4.9