### PR TITLE
(libretro)Silence warning

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -677,7 +677,8 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
    } while (*c++);
    */
    std::string codeLine=code;
-   std::string name="cheat_"+index;
+   std::string name="cheat_";
+   name += std::to_string(index);
    int matchLength=0;
    std::vector<std::string> codeParts;
    int cursor;


### PR DESCRIPTION
hopefully, std::to_string is not an issue with other supported systems....

```
../libretro/libretro.cpp:686:29: warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
   std::string name="cheat_"+index;
                    ~~~~~~~~^~~~~~
../libretro/libretro.cpp:686:29: note: use array indexing to silence this warning
   std::string name="cheat_"+index;
                            ^
                    &       [     ]

```