### PR TITLE
Allow game window to resize on-the-fly when enabling/disabling borders

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -581,8 +581,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
    if (type == IMAGE_GB) {
       aspect = !gbBorderOn ? (10.0 / 9.0) : (8.0 / 7.0);
-      maxWidth = sgbWidth;
-      maxHeight = sgbHeight;
+      maxWidth = !gbBorderOn ? gbWidth : sgbWidth;
+      maxHeight = !gbBorderOn ? gbHeight : sgbHeight;
    }
 
    info->geometry.base_width = systemWidth;


### PR DESCRIPTION
- Resizing is being triggered when max_width/max_height is changed
- Affects GB/GBC/SGB modes
- this should restore the original behavior before the change in RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO