### PR TITLE
HuC3: Refactoring to avoid breaking savestates

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -5515,6 +5515,8 @@ unsigned int gbWriteSaveState(uint8_t* data, unsigned)
     utilWriteMem(data, &gbDataMBC5, sizeof(gbDataMBC5));
     utilWriteMem(data, &gbDataHuC1, sizeof(gbDataHuC1));
     utilWriteMem(data, &gbDataHuC3, sizeof(gbDataHuC3));
+    if (gbRomType == 0xfe) // HuC3 rtc data
+        utilWriteMem(data, &gbRTCHuC3, sizeof(gbRTCHuC3));
     utilWriteMem(data, &gbDataTAMA5, sizeof(gbDataTAMA5));
     if (gbTAMA5ram != NULL)
         utilWriteMem(data, gbTAMA5ram, gbTAMA5ramSize);
@@ -5632,6 +5634,8 @@ bool gbReadSaveState(const uint8_t* data, unsigned)
     utilReadMem(&gbDataMBC5, data, sizeof(gbDataMBC5));
     utilReadMem(&gbDataHuC1, data, sizeof(gbDataHuC1));
     utilReadMem(&gbDataHuC3, data, sizeof(gbDataHuC3));
+    if (gbRomType == 0xfe) // HuC3 rtc data
+        utilReadMem(&gbRTCHuC3, data, sizeof(gbRTCHuC3));
     utilReadMem(&gbDataTAMA5, data, sizeof(gbDataTAMA5));
     if (gbTAMA5ram != NULL) {
         utilReadMem(gbTAMA5ram, data, gbTAMA5ramSize);

--- a/src/gb/gbMemory.h
+++ b/src/gb/gbMemory.h
@@ -77,12 +77,6 @@ struct mapperHuC1 {
     int mapperRAMAddress;
 };
 
-enum {
-    HUC3_READ = 0,
-    HUC3_WRITE = 1,
-    HUC3_NONE = 2
-};
-
 struct mapperHuC3 {
     int mapperRAMEnable;
     int mapperROMBank;
@@ -93,14 +87,29 @@ struct mapperHuC3 {
     int mapperRAMValue;
     int mapperRegister1;
     int mapperRegister2;
-    int mapperDateTime;
-    int mapperWritingTime;
-    int mapperModeFlag;
-    int mapperClockShift;
+    int mapperRegister3;
+    int mapperRegister4;
+    int mapperRegister5;
+    int mapperRegister6;
+    int mapperRegister7;
+    int mapperRegister8;
+};
+
+enum {
+    HUC3_READ = 0,
+    HUC3_WRITE = 1,
+    HUC3_NONE = 2
+};
+
+struct mapperHuC3RTC {
     union {
         time_t mapperLastTime;
         uint64_t _time_pad; /* so that 32bit and 64bit saves are compatible */
     };
+    uint32_t mapperDateTime;
+    uint32_t mapperWritingTime;
+    uint32_t mapperModeFlag;
+    uint32_t mapperClockShift;
 };
 
 struct mapperTAMA5 {
@@ -155,6 +164,7 @@ extern mapperMBC3 gbDataMBC3;
 extern mapperMBC5 gbDataMBC5;
 extern mapperHuC1 gbDataHuC1;
 extern mapperHuC3 gbDataHuC3;
+extern mapperHuC3RTC gbRTCHuC3;
 extern mapperTAMA5 gbDataTAMA5;
 extern mapperMMM01 gbDataMMM01;
 extern mapperGS3 gbDataGS3;

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -173,7 +173,7 @@ static void* gb_rtcdata_prt(void)
     case 0xfd: // TAMA5 + extended
         return &gbDataTAMA5.mapperSeconds;
     case 0xfe: // HuC3 + Clock
-        return &gbDataHuC3.mapperDateTime;
+        return &gbRTCHuC3.mapperLastTime;
     }
     return NULL;
 }
@@ -187,7 +187,7 @@ static size_t gb_rtcdata_size(void)
     case 0xfd: // TAMA5 + extended
         return TAMA5_RTC_DATA_SIZE;
     case 0xfe: // HuC3 + Clock
-        return HUC3_RTC_DATA_SIZE;
+        return sizeof(gbRTCHuC3);
     }
     return 0;
 }
@@ -1438,7 +1438,7 @@ void retro_run(void)
                     initRTC = true;
                 break;
             case 0xfe:
-                if (!gbDataHuC3.mapperLastTime)
+                if (!gbRTCHuC3.mapperLastTime)
                     initRTC = true;
                 break;
             }


### PR DESCRIPTION
Savestates are broken due to the change in savestate struct size for
HuC3. Since save/load function also includes save data for other
non-active mappers, the change in size breaks every savesfiles being
made.

This PR refactors the HuC3 clock data struct to be separate from the
main struct, and then only added to save/load functions when HuC3 mapper
is used. This still breaks previous HuC3 states but other mappers should
now not get affected

Solution:
Savestate/LoadState should only include mapper data of current active
running rom, not all mappers even if they are inactive. This will break
every savefile but it would be better for the long run when changes are
neede to be done.