### PR TITLE
Fix GameCube builds of VBA-M Libretro too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # Nintendo GameCube
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+
   # Nintendo Wii
   - project: 'libretro-infrastructure/ci-templates'
     file: '/wii-static.yml'
@@ -170,6 +174,12 @@ libretro-build-tvos-arm64:
 libretro-build-vita:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs
+    
+# Nintendo GameCube
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
     - .core-defs
     
 # Nintendo Wii

--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -286,7 +286,7 @@ else ifeq ($(platform), ngc)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	ENDIANNESS_DEFINES += -DMSB_FIRST
+	ENDIANNESS_DEFINES += -DMSB_FIRST -DWORDS_BIGENDIAN=1
 	PLATFORM_DEFINES += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__
 	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	STATIC_LINKING=1


### PR DESCRIPTION
The Nintendo GameCube is a big-endian system too (like Wii and Wii U), so let's fix video and emulation of VBA-M on GameCube too and include it on the nightly buildbot for NGC/GCN.