### PR TITLE
minor typo fixes

### DIFF
--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -97,7 +97,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "vbam_forceRTCenable",
         "Force-Enable RTC",
         NULL,
-        "Forces the internal real-time clock to be enabled regardless of rom. Usuable for rom patches that requires clock to be enabled (aka Pokemon).",
+        "Forces the internal real-time clock to be enabled regardless of rom. Useable for rom patches that require clock to be enabled (e.g., Pokemon).",
         NULL,
         "system",
         {


### PR DESCRIPTION
noticed some minor typos from within retroarch. the "e.g." is a guess; it could have also been intended to be "i.e.", but i thought "e.g." was more likely. "useable" was also a guess, but i thought it was more likely than "usual" due to being closer